### PR TITLE
FIX: correctly install pplacer during conda build

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -10,7 +10,9 @@ source:
   path: ../..
 
 build:
-  script: make install
+  script: |
+    make VERBOSE=1
+    make install    
 
 requirements:
   host:

--- a/install-pplacer.sh
+++ b/install-pplacer.sh
@@ -17,6 +17,7 @@ unzip pplacer.zip
 rm pplacer.zip
 
 if [[ "$PREFIX" == "" ]]; then
+  echo "Setting PREFIX=$CONDA_PREFIX"
   PREFIX="$CONDA_PREFIX"
 fi
 

--- a/install-pplacer.sh
+++ b/install-pplacer.sh
@@ -16,20 +16,20 @@ echo "Extracting..."
 unzip pplacer.zip
 rm pplacer.zip
 
-echo "Installing pplacer in $CONDA_PREFIX..."
-if [[ ! -d "$CONDA_PREFIX/bin/" ]]; then
-  mkdir $CONDA_PREFIX/bin/
+echo "Installing pplacer in $PREFIX..."
+if [[ ! -d "$PREFIX/bin/" ]]; then
+  mkdir $PREFIX/bin/
 fi
-mv pplacer*/guppy $CONDA_PREFIX/bin/
-mv pplacer*/pplacer $CONDA_PREFIX/bin/
-mv pplacer*/rppr $CONDA_PREFIX/bin/
+mv pplacer*/guppy $PREFIX/bin/
+mv pplacer*/pplacer $PREFIX/bin/
+mv pplacer*/rppr $PREFIX/bin/
 
-mkdir $CONDA_PREFIX/bin/scripts/
-mv pplacer*/scripts/* $CONDA_PREFIX/bin/scripts/
+mkdir $PREFIX/bin/scripts/
+mv pplacer*/scripts/* $PREFIX/bin/scripts/
 rm -r pplacer*
 
 echo "Testing installation..."
-if [[ $(which pplacer) == "$CONDA_PREFIX/bin"* ]]; then
+if [[ $(which pplacer) == "$PREFIX/bin"* ]]; then
   echo "Success!"
 # TODO: make sure later that this really is not necessary (try to install with conda on macOS and Ubuntu)
 #  pplacer --version

--- a/install-pplacer.sh
+++ b/install-pplacer.sh
@@ -16,6 +16,10 @@ echo "Extracting..."
 unzip pplacer.zip
 rm pplacer.zip
 
+if [[ "$PREFIX" == "" ]]; then
+  PREFIX="$CONDA_PREFIX"
+fi
+
 echo "Installing pplacer in $PREFIX..."
 if [[ ! -d "$PREFIX/bin/" ]]; then
   mkdir $PREFIX/bin/


### PR DESCRIPTION
Adjusts the pplacer installation script to use the `PREFIX` env variable when available (i.e., during conda builds) or `CONDA_PREFIX` when installing in an existing, activated conda environment.  