### PR TITLE
IMP: updates FeatureMap import for q2-types migration

### DIFF
--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -14,13 +14,13 @@ from q2_types.per_sample_sequences import (
     SequencesWithQuality, PairedEndSequencesWithQuality
 )
 from q2_types.sample_data import SampleData
+from q2_types.feature_map import FeatureMap, MAGtoContigs
 from qiime2.core.type import Bool, Range, Int, Str, Float, List, Choices
 from qiime2.core.type import (Properties, TypeMap)
 from qiime2.plugin import (Plugin, Citations)
 
 import q2_moshpit
 from q2_types_genomics.feature_data import NOG, MAG
-from q2_types_genomics.feature_map import FeatureMap, MAGtoContigs
 from q2_types_genomics.genome_data import BLAST6
 from q2_types_genomics.kraken2 import (
     Kraken2Reports, Kraken2Outputs, Kraken2DB


### PR DESCRIPTION
This PR updates the import of FeatureMap to originate from q2-types, accompanying this https://github.com/qiime2/q2-types/pull/303 which adds FeatureMap and associated formats to q2-types for use in q2-vsearch. This PR should not be merged until q2-types #303 has been merged.