### PR TITLE
BUG: test_draw_busco_plots_for_render is altair version variant

### DIFF
--- a/q2_moshpit/busco/tests/data/plot_as_dict.json
+++ b/q2_moshpit/busco/tests/data/plot_as_dict.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v5.15.1.json",
   "config": {
     "axis": {
       "labelFontSize": 17,
@@ -603,7 +602,7 @@
         "transform": [
           {
             "as": "x",
-            "calculate": "datum[param_2]"
+            "calculate": "datum[param_i]"
           }
         ],
         "width": 600
@@ -622,7 +621,7 @@
           "number_of_scaffolds"
         ]
       },
-      "name": "param_2",
+      "name": "param_i",
       "value": "scaffold_n50"
     }
   ],

--- a/q2_moshpit/busco/tests/test_utils.py
+++ b/q2_moshpit/busco/tests/test_utils.py
@@ -9,6 +9,7 @@
 import os
 import tempfile
 import zipfile
+import json
 import pandas as pd
 from q2_moshpit.busco.utils import (
     _parse_busco_params,
@@ -158,13 +159,26 @@ class TestBUSCO(TestPluginBase):
             labelFontSize=17,
         )
 
+        # Replace param value to make the dict altair version invariant
+        observed = observed.replace("param_1", "param_i")
+        observed = observed.replace("param_2", "param_i")
+
+        # Json string to dict
+        observed = json.loads(observed)
+
+        # Remove $schema k-v pair (also altair version variant)
+        observed.pop("$schema")
+
         # Load expected data
         p = self.get_data_path("plot_as_dict.json")
         with open(p, "r") as json_file:
             expected = json_file.read()
 
+        # Json string to dictionary
+        expected = json.loads(expected)
+
         self.maxDiff = None
-        self.assertEqual(expected, observed)
+        self.assertDictEqual(expected, observed)
 
     # Test `_draw_busco_plots`
     def mock_draw_busco_plots(self, tmp_path: str, num_files: int) -> dict:


### PR DESCRIPTION
**Closes #81**

In `busco/tests/test_utils.py` the `test_draw_busco_plots_for_render` function compares two dictionaries. Some of the entries in this dictionary change depending on the version of `altair` that is being used. I removed and edited these version-dependent keys to bypass the test failure. The rest of the dictionary is still compared. 