### PR TITLE
BUG: Eliminate MAG ID from y-axis to avoid misaligned plots

### DIFF
--- a/q2_moshpit/busco/tests/data/plot_as_dict.json
+++ b/q2_moshpit/busco/tests/data/plot_as_dict.json
@@ -463,7 +463,7 @@
       "facet": {
         "row": {
           "field": "sample_id",
-          "title": "Sample ID",
+          "title": "Sample ID / MAG ID",
           "type": "nominal"
         }
       },
@@ -541,7 +541,7 @@
           },
           "y": {
             "axis": {
-              "title": "MAG ID"
+              "titleFontSize": 0
             },
             "field": "mag_id",
             "type": "nominal"

--- a/q2_moshpit/busco/utils.py
+++ b/q2_moshpit/busco/utils.py
@@ -117,7 +117,7 @@ def _draw_busco_plots_for_render(
                 stack="normalize",
                 title="BUSCO fraction"
             ),
-            y=alt.Y("mag_id", axis=alt.Axis(title="MAG ID")),
+            y=alt.Y("mag_id", axis=alt.Axis(titleFontSize=0)),
             color=alt.Color(
                 "category",
                 scale=alt.Scale(domain=domain, range=range_),
@@ -143,7 +143,7 @@ def _draw_busco_plots_for_render(
         .facet(
             row=alt.Row(
                 "sample_id",
-                title="Sample ID"
+                title="Sample ID / MAG ID"
             ),
             spacing=spacing
         )


### PR DESCRIPTION
**Closes #84**

-  Eliminates MAG ID titles from y-axis to avoid misaligned plots