### PR TITLE
MAINT: clean up the input parameters to `evaluate-busco`

### DIFF
--- a/q2_moshpit/busco/busco.py
+++ b/q2_moshpit/busco/busco.py
@@ -40,19 +40,12 @@ def evaluate_busco(
     evalue: float = 1e-03,
     force: bool = False,
     limit: int = 3,
-    help: bool = False,
-    list_datasets: bool = False,
     long: bool = False,
     metaeuk_parameters: str = None,
     metaeuk_rerun_parameters: str = None,
     miniprot: bool = False,
-    offline: bool = False,
     quiet: bool = False,
-    restart: bool = False,
     scaffold_composition: bool = False,
-    tar: bool = False,
-    update_data: bool = False,
-    version: bool = False,
 ) -> None:
     """
     qiime2 visualization for the BUSCO assessment tool

--- a/q2_moshpit/busco/busco.py
+++ b/q2_moshpit/busco/busco.py
@@ -39,7 +39,6 @@ def evaluate_busco(
     metaeuk_parameters: str = None,
     metaeuk_rerun_parameters: str = None,
     miniprot: bool = False,
-    quiet: bool = False,
     scaffold_composition: bool = False,
 ) -> None:
     """

--- a/q2_moshpit/busco/busco.py
+++ b/q2_moshpit/busco/busco.py
@@ -15,7 +15,6 @@ from q2_moshpit.busco.utils import (
     _render_html,
 )
 from q2_moshpit._utils import _process_common_input_params
-from typing import List
 from q2_types_genomics.per_sample_data._format import MultiMAGSequencesDirFmt
 
 
@@ -33,10 +32,6 @@ def evaluate_busco(
     cpu: int = 1,
     config: str = None,
     contig_break: int = 10,
-    datasets_version: str = None,
-    download: List[str] = None,
-    download_base_url: str = None,
-    download_path: str = None,
     evalue: float = 1e-03,
     force: bool = False,
     limit: int = 3,

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -664,23 +664,17 @@ busco_params = {
     "evalue": Float % Range(0, None, inclusive_start=False),
     "force": Bool,
     "limit": Int % Range(1, 20),
-    "help": Bool,
-    "list_datasets": Bool,
     "long": Bool,
     "metaeuk_parameters": Str,
     "metaeuk_rerun_parameters": Str,
     "miniprot": Bool,
-    "offline": Bool,
     "quiet": Bool,
-    "restart": Bool,
     "scaffold_composition": Bool,
-    "tar": Bool,
-    "update_data": Bool,
     "version": Bool,
 }
 busco_param_descriptions = {
     "mode": "Specify which BUSCO analysis mode to run."
-            "Currently only the 'genome' or 'geno' option is supported, "
+            "Currently only the 'genome' option is supported, "
             "for genome assemblies. In the future modes for transcriptome "
             "assemblies and for annotated gene sets (proteins) will be made "
             "available.",
@@ -717,10 +711,8 @@ busco_param_descriptions = {
               "Allowed formats, 0.001 or 1e-03, Default: 1e-03.",
     "force": "Force rewriting of existing files. Must be used when output "
              "files with the provided name already exist.",
-    "help": "Show this help message and exit.",
     "limit": "How many candidate regions (contig or transcript) to consider "
              "per BUSCO. Default: 3.",
-    "list_datasets": "Print the list of available BUSCO datasets.",
     "long": "Optimization Augustus self-training mode (Default: Off); "
             "adds considerably to the run time, "
             "but can improve results for some non-model organisms.",
@@ -736,16 +728,9 @@ busco_param_descriptions = {
                                 "a comma. "
                                 "Example: `--PARAM1=VALUE1,--PARAM2=VALUE2`.",
     "miniprot": "Use miniprot gene predictor for eukaryote runs.",
-    "offline": "To indicate that BUSCO cannot attempt to download files.",
     "quiet": "Disable the info logs, displays only errors.",
-    "restart": "Continue a run that had already partially completed.",
     "scaffold_composition": "Writes ACGTN content per scaffold to a file "
                             "`scaffold_composition.txt`.",
-    "tar": "Compress some subdirectories with many files to save space.",
-    "update_data": "Download and replace with last versions all lineages "
-                   "datasets and files necessary to their automated "
-                   "selection.",
-    "version": "Show this version and exit.",
 }
 
 

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -665,7 +665,7 @@ busco_params = {
     "metaeuk_rerun_parameters": Str,
     "miniprot": Bool,
     "quiet": Bool,
-    "scaffold_composition": Bool
+    "scaffold_composition": Bool,
 }
 busco_param_descriptions = {
     "mode": "Specify which BUSCO analysis mode to run."

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -664,7 +664,6 @@ busco_params = {
     "metaeuk_parameters": Str,
     "metaeuk_rerun_parameters": Str,
     "miniprot": Bool,
-    "quiet": Bool,
     "scaffold_composition": Bool,
 }
 busco_param_descriptions = {
@@ -715,7 +714,6 @@ busco_param_descriptions = {
                                 "a comma. "
                                 "Example: `--PARAM1=VALUE1,--PARAM2=VALUE2`.",
     "miniprot": "Use miniprot gene predictor for eukaryote runs.",
-    "quiet": "Disable the info logs, displays only errors.",
     "scaffold_composition": "Writes ACGTN content per scaffold to a file "
                             "`scaffold_composition.txt`.",
 }

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -657,10 +657,6 @@ busco_params = {
     "cpu": Int % Range(1, None),
     "config": Str,
     "contig_break": Int % Range(0, None),
-    "datasets_version": Str,
-    "download": List[Str],
-    "download_base_url": Str,
-    "download_path": Str,
     "evalue": Float % Range(0, None, inclusive_start=False),
     "force": Bool,
     "limit": Int % Range(1, 20),
@@ -698,14 +694,6 @@ busco_param_descriptions = {
                     "contigs. Default is n=10. "
                     "See https://gitlab.com/ezlab/busco/-/issues/691 for a "
                     "more detailed explanation.",
-    "datasets_version": "Specify the version of BUSCO datasets, e.g. odb10.",
-    "download": "Download dataset. Possible values are a specific dataset "
-                "name, 'all', 'prokaryota', 'eukaryota', or 'virus'. "
-                "If used together with other command line arguments, "
-                "make sure to place this last. Example: '[dataset ...]'.",
-    "download_base_url": "Set the url to the remote BUSCO dataset location.",
-    "download_path": "Specify local filepath for storing BUSCO dataset "
-                     "downloads.",
     "evalue": "E-value cutoff for BLAST searches. "
               "Allowed formats, 0.001 or 1e-03, Default: 1e-03.",
     "force": "Force rewriting of existing files. Must be used when output "

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -669,8 +669,7 @@ busco_params = {
     "metaeuk_rerun_parameters": Str,
     "miniprot": Bool,
     "quiet": Bool,
-    "scaffold_composition": Bool,
-    "version": Bool,
+    "scaffold_composition": Bool
 }
 busco_param_descriptions = {
     "mode": "Specify which BUSCO analysis mode to run."


### PR DESCRIPTION
### What's new
- Removes useless parameters from action `evaluate-busco`
- Closes #113 

### Additional information
- Not blocked by anything 🥳 

### Set up an environment
```bash
# For linux: 
# export MY_OS="linux"
# For mac:
export MY_OS="osx" 
wget "https://data.qiime2.org/distro/shotgun/qiime2-shotgun-2023.9-py38-"$MY_OS"-conda.yml"
conda env create -n q2-shotgun --file qiime2-shotgun-2023.9-py38-osx-conda.yml
rm "qiime2-shotgun-2023.9-py38-"$MY_OS"-conda.yml"
```

### Run it locally 
1. Clone the repo and checkout the PR branch (skip this step if you already have a local copy of the code):
```bash
# Remove q2-moshpit and q2-types-genomics so you can install your local version.
conda activate q2-shotgun
conda remove q2-moshpit

# clone from GitHub
git clone git@github.com:bokulich-lab/q2-moshpit.git
cd q2-moshpit
gh pr checkout 121
pip install -e .
```

3. Test it out!
```bash
qiime dev refresh-cache
```

### Running the tests
```bash
pytest -W ignore -vv --pyargs q2_moshpit
```