### PR TITLE
BUG: pin `busco` version to `5.5.0`

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - altair
     - beautifulsoup4
     - bracken
-    - busco >=5.0.0
+    - busco ==5.0.0
     - diamond
     - eggnog-mapper >=2.1.10
     - kaiju


### PR DESCRIPTION
- Closes #130 
- `busco==5.6.1` requires `biopython>=1.79`. Because q2-assembly needs `biopython<=1.78` we rather pin busco to version 5.5.0. See the issue above for more info. 