### PR TITLE
ENH: Expose `cpu` param in `eggnog-annotate` action.

### DIFF
--- a/q2_moshpit/eggnog/_method.py
+++ b/q2_moshpit/eggnog/_method.py
@@ -99,7 +99,8 @@ def _diamond_search_runner(input_path, diamond_db, sample_label, output_loc,
 
 def eggnog_annotate(eggnog_hits: SeedOrthologDirFmt,
                     eggnog_db: EggnogRefDirFmt,
-                    db_in_memory: bool = False) -> OrthologAnnotationDirFmt:
+                    db_in_memory: bool = False,
+                    num_cpus: int = 1) -> OrthologAnnotationDirFmt:
 
     eggnog_db_fp = eggnog_db.path
 
@@ -114,20 +115,22 @@ def eggnog_annotate(eggnog_hits: SeedOrthologDirFmt,
                                         eggnog_db=eggnog_db_fp,
                                         sample_label=sample_label,
                                         output_loc=result,
-                                        db_in_memory=db_in_memory)
+                                        db_in_memory=db_in_memory,
+                                        num_cpus=num_cpus)
 
     return result
 
 
 def _annotate_seed_orthologs_runner(seed_ortholog, eggnog_db, sample_label,
-                                    output_loc, db_in_memory):
+                                    output_loc, db_in_memory, num_cpus):
 
     # at this point instead of being able to specify the type of target
     # orthologs, we want to annotate _all_.
 
     cmds = ['emapper.py', '-m', 'no_search', '--annotate_hits_table',
             str(seed_ortholog), '--data_dir', str(eggnog_db),
-            '-o', str(sample_label), '--output_dir', str(output_loc)]
+            '-o', str(sample_label), '--output_dir', str(output_loc),
+            '--cpu', str(num_cpus)]
     if db_in_memory:
         cmds.append('--dbmem')
 

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -694,12 +694,15 @@ plugin.methods.register_function(
     },
     parameters={
         'db_in_memory': Bool,
+        'num_cpus': Int % Range(0, None)
     },
     parameter_descriptions={
         'db_in_memory': 'Read eggnog database into memory. The '
                         'eggnog database is very large(>44GB), so this '
                         'option should only be used on clusters or other '
                         'machines with enough memory.',
+        'num_cpus': 'Number of CPUs to utilize. \'0\' will '
+                    'use all available.',
     },
     outputs=[('ortholog_annotations', FeatureData[NOG])],
     name='Annotate orthologs against eggNOG database',


### PR DESCRIPTION
### What's new
- The eggnog-annotate action wrapps the emapper.py script from eggnog to perform annotations.
- The emapper.py script allows users to specify the number of cpu's with the --cpu flag.
- However this parameter is not exposed in the eggnog-annotate action.
- This PR exposes the `--cpu` parameter such that users can use this functionality.
- Closes #135 

### Set up an environment
```bash
# For linux: 
# export MY_OS="linux"
# For mac:
export MY_OS="osx" 
wget "https://data.qiime2.org/distro/shotgun/qiime2-shotgun-2023.9-py38-"$MY_OS"-conda.yml"
conda env create -n q2-shotgun --file qiime2-shotgun-2023.9-py38-osx-conda.yml
rm "qiime2-shotgun-2023.9-py38-"$MY_OS"-conda.yml"
```

Now clone the repo and checkout the PR branch (skip this step if you already have a local copy of the code):
```bash
# Remove q2-moshpit so you can install your local version.
conda activate q2-shotgun
conda remove q2-moshpit

# clone from GitHub
git clone git@github.com:bokulich-lab/q2-moshpit.git
cd q2-moshpit
gh pr checkout 136
pip install -e .
```

### Run it locally

1. Let's get you some data to play with: 
```bash
TODO
```

2. Test it out!
```bash
qiime moshpit eggnog-annotate --p-num-cpus 2 ...TODO... --verbose
```

### Running the tests
```bash
pytest -W ignore -vv --pyargs q2_moshpit
```
