### PR TITLE
ENH: parallelize `eggnong-annotate`

### DIFF
--- a/q2_moshpit/eggnog/__init__.py
+++ b/q2_moshpit/eggnog/__init__.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 from ._method import (
     eggnog_diamond_search, _eggnog_diamond_search, eggnog_annotate,
-    _eggnog_feature_table
+    _eggnog_feature_table, _eggnog_annotate
 )
 from ._dbs import (
     fetch_eggnog_db, fetch_diamond_db, build_custom_diamond_db,
@@ -19,5 +19,5 @@ __all__ = [
     'eggnog_diamond_search', '_eggnog_diamond_search', 'eggnog_annotate',
     '_eggnog_feature_table', 'fetch_eggnog_db', 'fetch_diamond_db',
     'build_custom_diamond_db', 'fetch_eggnog_proteins',
-    'build_eggnog_diamond_db', 'fetch_ncbi_taxonomy'
+    'build_eggnog_diamond_db', 'fetch_ncbi_taxonomy', '_eggnog_annotate'
 ]

--- a/q2_moshpit/eggnog/_method.py
+++ b/q2_moshpit/eggnog/_method.py
@@ -134,10 +134,12 @@ def _diamond_search_runner(input_path, diamond_db, sample_label, output_loc,
     subprocess.run(cmds, check=True)
 
 
-def _eggnog_annotate(eggnog_hits: SeedOrthologDirFmt,
-                    eggnog_db: EggnogRefDirFmt,
-                    db_in_memory: bool = False,
-                    num_cpus: int = 1) -> OrthologAnnotationDirFmt:
+def _eggnog_annotate(
+        eggnog_hits: SeedOrthologDirFmt,
+        eggnog_db: EggnogRefDirFmt,
+        db_in_memory: bool = False,
+        num_cpus: int = 1
+) -> OrthologAnnotationDirFmt:
 
     eggnog_db_fp = eggnog_db.path
 

--- a/q2_moshpit/eggnog/_method.py
+++ b/q2_moshpit/eggnog/_method.py
@@ -17,7 +17,7 @@ from q2_types.genome_data import SeedOrthologDirFmt, OrthologFileFmt
 from q2_types.reference_db import (
     EggnogRefDirFmt, DiamondDatabaseDirFmt
 )
-from q2_types.feature_data import DNAFASTAFormat, FeatureData
+from q2_types.feature_data import DNAFASTAFormat, FeatureData, BLAST6
 from q2_types.feature_data_mag import (
     OrthologAnnotationDirFmt, MAGSequencesDirFmt, MAG
 )
@@ -134,7 +134,7 @@ def _diamond_search_runner(input_path, diamond_db, sample_label, output_loc,
     subprocess.run(cmds, check=True)
 
 
-def eggnog_annotate(eggnog_hits: SeedOrthologDirFmt,
+def _eggnog_annotate(eggnog_hits: SeedOrthologDirFmt,
                     eggnog_db: EggnogRefDirFmt,
                     db_in_memory: bool = False,
                     num_cpus: int = 1) -> OrthologAnnotationDirFmt:
@@ -156,6 +156,35 @@ def eggnog_annotate(eggnog_hits: SeedOrthologDirFmt,
                                         num_cpus=num_cpus)
 
     return result
+
+
+def eggnog_annotate(
+        ctx,
+        eggnog_hits,
+        eggnog_db,
+        db_in_memory=False,
+        num_cpus=1,
+        num_partitions=None
+):
+    _eggnog_annotate = ctx.get_action("moshpit", "_eggnog_annotate")
+    collate_annotations = ctx.get_action("moshpit", "collate_annotations")
+
+    if eggnog_hits.type <= SampleData[BLAST6]:
+        partition_method = ctx.get_action("moshpit", "partition_orthologs")
+    else:
+        raise NotImplementedError()
+
+    (partitioned_orthologs, ) = partition_method(eggnog_hits, num_partitions)
+
+    annotations = []
+    for orthologs in partitioned_orthologs.values():
+        (annotation, ) = _eggnog_annotate(
+            orthologs, eggnog_db, db_in_memory, num_cpus
+        )
+        annotations.append(annotation)
+
+    (collated_annotations, ) = collate_annotations(annotations)
+    return collated_annotations
 
 
 def _annotate_seed_orthologs_runner(seed_ortholog, eggnog_db, sample_label,

--- a/q2_moshpit/eggnog/tests/test_method.py
+++ b/q2_moshpit/eggnog/tests/test_method.py
@@ -5,18 +5,20 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import filecmp
 import qiime2
 import pandas as pd
 import pandas.testing as pdt
 from qiime2.plugin.testing import TestPluginBase
 from qiime2.sdk.parallel_config import ParallelConfig
 from q2_types.feature_data_mag import MAGSequencesDirFmt
-from .._method import _eggnog_diamond_search, eggnog_annotate
+from .._method import _eggnog_diamond_search, _eggnog_annotate
 from q2_types.reference_db import (
     DiamondDatabaseDirFmt, EggnogRefDirFmt
 )
 from q2_types.per_sample_sequences import ContigSequencesDirFmt
 from q2_types.genome_data import SeedOrthologDirFmt, OrthologFileFmt
+from q2_types.feature_data_mag import OrthologAnnotationDirFmt
 
 
 class TestDiamond(TestPluginBase):
@@ -118,19 +120,60 @@ class TestDiamond(TestPluginBase):
 class TestAnnotate(TestPluginBase):
     package = 'q2_moshpit.eggnog.tests'
 
+    def setUp(self):
+        super().setUp()
+        self.eggnog_db = EggnogRefDirFmt(
+            self.get_data_path('eggnog_db/'), mode='r'
+        )
+        self.eggnog_db_artifact = qiime2.Artifact.import_data(
+            'ReferenceDB[Eggnog]',
+            self.get_data_path('eggnog_db/')
+        )
+        self.eggnog_annotate = \
+            self.plugin.pipelines["eggnog_annotate"]
+        self._eggnog_annotate = \
+            self.plugin.methods["_eggnog_annotate"]
+
     def test_small_good_hits(self):
-        so_fp = self.get_data_path('good_hits/')
-        seed_orthologs = SeedOrthologDirFmt(so_fp, mode='r')
+        seed_orthologs = SeedOrthologDirFmt(
+            self.get_data_path('good_hits/'), mode='r'
+        )
 
-        egg_db_fp = self.get_data_path('eggnog_db/')
-        egg_db = EggnogRefDirFmt(egg_db_fp, mode='r')
+        obs_obj = _eggnog_annotate(
+            eggnog_hits=seed_orthologs, eggnog_db=self.eggnog_db
+        )
 
-        obs_obj = eggnog_annotate(eggnog_hits=seed_orthologs, eggnog_db=egg_db)
-
-        exp_fp = self.get_data_path('expected/test_output.emapper.annotations')
+        exp_fp = self.get_data_path(
+            'expected/test_output.emapper.annotations'
+        )
         exp = OrthologFileFmt(exp_fp, mode='r').view(pd.DataFrame)
 
         objs = list(obs_obj.annotations.iter_views(OrthologFileFmt))
         self.assertEqual(len(objs), 1)
         df = objs[0][1].view(pd.DataFrame)
         pdt.assert_frame_equal(df, exp)
+
+    def test_eggnog_annotate_parallel(self):
+        orthologs = qiime2.Artifact.import_data(
+            'SampleData[BLAST6]',
+            self.get_data_path('good_hits/')
+        )
+
+        with ParallelConfig():
+            parallel, = self.eggnog_annotate.parallel(
+                    orthologs,
+                    self.eggnog_db_artifact
+                )._result()
+
+        single, = self._eggnog_annotate(
+            eggnog_hits=orthologs,
+            eggnog_db=self.eggnog_db_artifact
+        )
+
+        parallel = parallel.view(OrthologAnnotationDirFmt)
+        single = single.view(OrthologAnnotationDirFmt)
+
+        compare_dir = filecmp.dircmp(parallel.path, single.path)
+        self.assertEqual(len(compare_dir.common), 1)
+
+        # TODO: add exact file comparison

--- a/q2_moshpit/partition/__init__.py
+++ b/q2_moshpit/partition/__init__.py
@@ -8,12 +8,15 @@
 from .annotations import collate_annotations
 from .mags import (
     collate_feature_data_mags, collate_sample_data_mags,
-    partition_feature_data_mags, partition_sample_data_mags
+    partition_feature_data_mags, partition_sample_data_mags,
+
 )
-from .ortholog import collate_orthologs
+from .ortholog import (
+    collate_orthologs, partition_orthologs
+)
 
 __all__ = [
     "collate_feature_data_mags", "collate_sample_data_mags",
     "partition_feature_data_mags", "partition_sample_data_mags",
-    "collate_orthologs", "collate_annotations"
+    "collate_orthologs", "partition_orthologs", "collate_annotations"
 ]

--- a/q2_moshpit/partition/ortholog.py
+++ b/q2_moshpit/partition/ortholog.py
@@ -72,18 +72,3 @@ def partition_orthologs(
             partitioned_orthologs[i] = result
 
     return partitioned_orthologs
-
-
-# borrowed from Santiago
-def collate_annotations(
-    ortholog_annotations: OrthologAnnotationDirFmt
-) -> OrthologAnnotationDirFmt:
-    # Init output
-    collated_annotations = OrthologAnnotationDirFmt()
-
-    # Copy annotations into output
-    for anno in ortholog_annotations:
-        for fp in anno.path.iterdir():
-            duplicate(fp, collated_annotations.path / fp.name)
-
-    return collated_annotations

--- a/q2_moshpit/partition/ortholog.py
+++ b/q2_moshpit/partition/ortholog.py
@@ -5,10 +5,15 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import glob
 import os
 import shutil
+import warnings
 
+import numpy as np
+from q2_types.feature_data_mag import OrthologAnnotationDirFmt
 from q2_types.genome_data import SeedOrthologDirFmt
+from qiime2.util import duplicate
 
 
 def collate_orthologs(orthologs: SeedOrthologDirFmt) -> SeedOrthologDirFmt:
@@ -19,3 +24,66 @@ def collate_orthologs(orthologs: SeedOrthologDirFmt) -> SeedOrthologDirFmt:
             shutil.move(fp, result.path / os.path.basename(fp))
 
     return result
+
+
+def partition_orthologs(
+        orthologs: SeedOrthologDirFmt, num_partitions: int = None
+) -> SeedOrthologDirFmt:
+    """
+    Returns a dictionary where each key is either the sample_id and
+    values are the new objects with the orthologs.
+    """
+    partitioned_orthologs = {}
+
+    # TODO: this logic should move to the format itself
+    orthologs = glob.glob(os.path.join(str(orthologs), "*.seed_orthologs"))
+    names = [
+        os.path.basename(x).replace(".emapper.seed_orthologs", "") for x in orthologs
+    ]
+    orthologs = list(zip(names, orthologs))
+
+    num_samples = len(orthologs)
+    if num_partitions is None:
+        num_partitions = num_samples
+    elif num_partitions > num_samples:
+        warnings.warn(
+            "You have requested a number of partitions"
+            f" '{num_partitions}' that is greater than your number"
+            f" of samples '{num_samples}.' Your data will be"
+            f" partitioned by sample into '{num_samples}'"
+            " partitions."
+        )
+        num_partitions = num_samples
+
+    orthologs = np.array_split(orthologs, num_partitions)
+    for i, samples in enumerate(orthologs, 1):
+        result = SeedOrthologDirFmt()
+
+        for sample_id, sample_fp in samples:
+            duplicate(sample_fp, result.path / os.path.basename(sample_fp))
+
+        # If num_partitions == num_samples we will only have gone through one
+        # sample in the above loop and will use its id as a key. Otherwise we
+        # may have gone through multiple samples in the above loop and will be
+        # using indices for keys
+        if num_partitions == num_samples:
+            partitioned_orthologs[sample_id] = result
+        else:
+            partitioned_orthologs[i] = result
+
+    return partitioned_orthologs
+
+
+# borrowed from Santiago
+def collate_annotations(
+    ortholog_annotations: OrthologAnnotationDirFmt
+) -> OrthologAnnotationDirFmt:
+    # Init output
+    collated_annotations = OrthologAnnotationDirFmt()
+
+    # Copy annotations into output
+    for anno in ortholog_annotations:
+        for fp in anno.path.iterdir():
+            duplicate(fp, collated_annotations.path / fp.name)
+
+    return collated_annotations

--- a/q2_moshpit/partition/ortholog.py
+++ b/q2_moshpit/partition/ortholog.py
@@ -11,7 +11,6 @@ import shutil
 import warnings
 
 import numpy as np
-from q2_types.feature_data_mag import OrthologAnnotationDirFmt
 from q2_types.genome_data import SeedOrthologDirFmt
 from qiime2.util import duplicate
 
@@ -38,7 +37,8 @@ def partition_orthologs(
     # TODO: this logic should move to the format itself
     orthologs = glob.glob(os.path.join(str(orthologs), "*.seed_orthologs"))
     names = [
-        os.path.basename(x).replace(".emapper.seed_orthologs", "") for x in orthologs
+        os.path.basename(x).replace(".emapper.seed_orthologs", "")
+        for x in orthologs
     ]
     orthologs = list(zip(names, orthologs))
 

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -829,24 +829,6 @@ plugin.methods.register_function(
 )
 
 plugin.methods.register_function(
-    function=q2_moshpit.partition.collate_annotations,
-    inputs={'ortholog_annotations': List[FeatureData[NOG]]},
-    parameters={},
-    outputs=[('collated_annotations', FeatureData[NOG])],
-    input_descriptions={
-        'ortholog_annotations': "Collection of orthologs annotations"
-    },
-    output_descriptions={
-        'collated_annotations': "Collated orthologs annotations"
-    },
-    name='Collate orthologs annotations',
-    description="Collate orthologs annotations from the eggnog-annotate "
-                "action. Intended when parallel runs of eggnog-diamond-search "
-                "and eggnog-annotate were used.",
-)
-
-
-plugin.methods.register_function(
     function=q2_moshpit.partition.collate_sample_data_mags,
     inputs={"mags": List[SampleData[MAGs]]},
     parameters={},


### PR DESCRIPTION
Adds support for parallelization of the `eggnog-annotate` action.