### PR TITLE
MAINT: complete the description of inputs and outputs in `eggnog-annotate` and `eggnog-diamond-search`

### DIFF
--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -720,13 +720,9 @@ plugin.methods.register_function(
         ('table', FeatureTable[Frequency])
     ],
     output_descriptions={
-        'eggnog_hits': 'Table(s) describing the alignment hits '
-                       '(BLAST6 format).'
-                       'One table per sample or MAGs in the input.',
-        'table': 'Table where rows are subject sequence IDs and columns are '
-                 'MAGs or samples IDs. Values are counts, i.e. the amount of '
-                 'times a given subject sequence was found to be a hit in a '
-                 'given sample of MAG.'
+        'eggnog_hits': 'BLAST6-like table(s) describing the identified orthologs. '
+                       'One table per sample or MAG in the input.',
+        'table': 'Feature table with counts of orthologs per sample/MAG.'
     },
     name='Run eggNOG search using diamond aligner',
     description="This method performs the steps by which we find our "
@@ -763,9 +759,7 @@ plugin.pipelines.register_function(
         'eggnog_db': ReferenceDB[Eggnog],
     },
     input_descriptions={
-        'eggnog_hits': 'Table(s) describing the alignment hits '
-                       '(BLAST6 format).'
-                       'One table per sample or MAGs in the input.',
+        'eggnog_hits': 'BLAST6-like table(s) describing the identified orthologs. ',
         "eggnog_db": "eggNOG annotation database."
     },
     parameters={
@@ -893,7 +887,7 @@ plugin.methods.register_function(
     input_descriptions={"orthologs": "Orthologs to collate"},
     parameter_descriptions={},
     name="Collate Orthologs",
-    description="Takes a collection SampleData[BLAST6]'s "
+    description="Takes a collection SampleData[BLAST6] artifacts "
                 "and collates them into a single artifact.",
 )
 

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -843,8 +843,8 @@ plugin.methods.register_function(
         " MAGs."
     },
     name="Partition orthologs",
-    description="Partition a SampleData[MAGs] artifact into smaller "
-                "artifacts containing subsets of the MAGs",
+    description="Partition a SampleData[BLAST6] artifact into smaller "
+                "artifacts containing subsets of the BLAST6 reports.",
 )
 
 plugin.methods.register_function(
@@ -893,7 +893,8 @@ plugin.methods.register_function(
     input_descriptions={"orthologs": "Orthologs to collate"},
     parameter_descriptions={},
     name="Collate Orthologs",
-    description="Collate a List of SampleData[BLAST6] into one"
+    description="Takes a collection SampleData[BLAST6]'s "
+                "and collates them into a single artifact.",
 )
 
 plugin.methods.register_function(

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -719,6 +719,15 @@ plugin.methods.register_function(
         ('eggnog_hits', SampleData[BLAST6]),
         ('table', FeatureTable[Frequency])
     ],
+    output_descriptions={
+        'eggnog_hits': 'Table(s) describing the alignment hits '
+                       '(BLAST6 format).'
+                       'One table per sample or MAGs in the input.',
+        'table': 'Table where rows are subject sequence IDs and columns are '
+                 'MAGs or samples IDs. Values are counts, i.e. the amount of '
+                 'times a given subject sequence was found to be a hit in a '
+                 'given sample of MAG.'
+    },
     name='Run eggNOG search using diamond aligner',
     description="This method performs the steps by which we find our "
                 "possible target sequences to annotate using the diamond "
@@ -753,6 +762,12 @@ plugin.pipelines.register_function(
         'eggnog_hits': SampleData[BLAST6],
         'eggnog_db': ReferenceDB[Eggnog],
     },
+    input_descriptions={
+        'eggnog_hits': 'Table(s) describing the alignment hits '
+                       '(BLAST6 format).'
+                       'One table per sample or MAGs in the input.',
+        "eggnog_db": "eggNOG annotation database."
+    },
     parameters={
         'db_in_memory': Bool,
         'num_cpus': Int % Range(0, None),
@@ -768,6 +783,9 @@ plugin.pipelines.register_function(
         **partition_param_descriptions
     },
     outputs=[('ortholog_annotations', FeatureData[NOG])],
+    output_descriptions={
+        'ortholog_annotations': 'Annotated hits.'
+    },
     name='Annotate orthologs against eggNOG database',
     description="Apply eggnog mapper to annotate seed orthologs.",
     citations=[citations["huerta_cepas_eggnog_2019"]]


### PR DESCRIPTION
The description for inputs and outputs was missing in `eggnog-annotate`. Similarly the description of the outputs was missing in `eggnog-diamond-search`. This PR adds said descriptions. 