### PR TITLE
BUG: add mags-derep test dir to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'q2_moshpit': [
             'citations.bib',
             'tests/data/*',
+            'tests/data/mags-derep/*',
             'tests/data/md5/*',
             "assets/busco/*",
             "assets/busco/feature_data/*",


### PR DESCRIPTION
hey @misialq! looks like this test data dir was missing from the package data - this was our only test failure in the metagenome prepare PR (link [here](https://github.com/qiime2/distributions/actions/runs/9175496269/job/25337187346?pr=249#step:9:268)), so once this gets merged we should have a passing prepare! 🙂 