### PR TITLE
TEST: include missing busco test files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "data/*/*/*",
             "data/*/*/*/*",
             "data/*/*/*/*/*",
+            "data/*/*/*/*/*/*",
         ],
         "q2_moshpit.busco.types.tests": [
             "data/*",

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,18 @@ setup(
             'data/depth/*', 'data/maps/*', 'data/bins-small/*/*',
             'data/bins-no-uuid/*/*'
         ],
-        "q2_moshpit.busco.tests": [
-            "data/*",
-            "data/*/*",
-            "data/*/*/*",
-            "data/*/*/*/*",
-            "data/*/*/*/*/*",
-            "data/*/*/*/*/*/*",
+        "q2_moshpit.busco.tests.data": [
+            "*",
+            "summaries/*",
+            "mags/*",
+            "mags/sample1/*",
+            "mags/sample2/*",
+            "busco_db/busco_downloads/*",
+            "busco_db/busco_downloads/placement_files/*",
+            "busco_db/busco_downloads/lineages/lineage_1/*",
+            "busco_db/busco_downloads/lineages/lineage_1/hmms/*",
+            "busco_db/busco_downloads/lineages/lineage_1/info/*",
+            "busco_db/busco_downloads/lineages/lineage_1/prfl/*"
         ],
         "q2_moshpit.busco.types.tests": [
             "data/*",


### PR DESCRIPTION
`test_busco_feature_data.py::TestBUSCOFeatureData::test_evaluate_busco_action` and `test_busco_sample_data.py::TestBUSCOSampleData::test_evaluate_busco_action` failing because test data is missing. This PR includes such data by specifying it in the `setup.py`.