### PR TITLE
MAINT: update Python version in test CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["main"]
 env:
-    DISTRO: tiny
+    DISTRO: metagenome
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["main"]
 env:
-    DISTRO: metagenome
+    DISTRO: tiny
 
 jobs:
   test:
@@ -58,7 +58,7 @@ jobs:
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.8
+          python-version: 3.9
           mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true


### PR DESCRIPTION
This PR updates Python version to 3.9 in our "Test" CI, following the recent update in the QIIME 2 distros.