### PR TITLE
REF: remove private imports for q2-types refactor

### DIFF
--- a/q2_moshpit/busco/busco.py
+++ b/q2_moshpit/busco/busco.py
@@ -27,9 +27,9 @@ from q2_moshpit.busco.utils import (
     _validate_lineage_dataset_input
 )
 from q2_moshpit._utils import _process_common_input_params, run_command
-from q2_types.per_sample_sequences._format import MultiMAGSequencesDirFmt
+from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 from q2_moshpit.busco.types import BuscoDatabaseDirFmt
-from q2_types.feature_data_mag._format import MAGSequencesDirFmt
+from q2_types.feature_data_mag import MAGSequencesDirFmt
 
 
 def _run_busco(

--- a/q2_moshpit/busco/tests/test_busco_sample_data.py
+++ b/q2_moshpit/busco/tests/test_busco_sample_data.py
@@ -16,7 +16,7 @@ from q2_moshpit.busco.busco import (
 )
 from unittest.mock import patch, ANY, call, MagicMock
 from qiime2.plugin.testing import TestPluginBase
-from q2_types.per_sample_sequences._format import MultiMAGSequencesDirFmt
+from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 from q2_moshpit.busco.types import BuscoDatabaseDirFmt
 
 

--- a/q2_moshpit/busco/tests/test_utils.py
+++ b/q2_moshpit/busco/tests/test_utils.py
@@ -14,7 +14,7 @@ from q2_moshpit.busco.utils import (
     _partition_dataframe, _get_feature_table, _calculate_summary_stats,
     _get_mag_lengths, _validate_lineage_dataset_input
 )
-from q2_types.per_sample_sequences._format import MultiMAGSequencesDirFmt
+from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 from q2_types.feature_data_mag import MAGSequencesDirFmt
 from q2_moshpit.busco.types import BuscoDatabaseDirFmt
 

--- a/q2_moshpit/dereplication/tests/test_dereplication.py
+++ b/q2_moshpit/dereplication/tests/test_dereplication.py
@@ -19,7 +19,7 @@ from q2_moshpit.dereplication.derep import (
     dereplicate_mags
 )
 from q2_types.feature_data_mag import MAGSequencesDirFmt
-from q2_types.per_sample_sequences._format import MultiMAGSequencesDirFmt
+from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 
 from qiime2.plugin.testing import TestPluginBase
 

--- a/q2_moshpit/metabat2/metabat2.py
+++ b/q2_moshpit/metabat2/metabat2.py
@@ -19,7 +19,7 @@ import skbio.io
 from q2_types.feature_data import DNAIterator
 
 from q2_types.per_sample_sequences import ContigSequencesDirFmt, BAMDirFmt
-from q2_types.per_sample_sequences._format import MultiFASTADirectoryFormat
+from q2_types.per_sample_sequences import MultiFASTADirectoryFormat
 
 from q2_moshpit._utils import run_command, _process_common_input_params
 from q2_moshpit.metabat2.utils import _process_metabat2_arg

--- a/q2_moshpit/metabat2/tests/test_metabat2.py
+++ b/q2_moshpit/metabat2/tests/test_metabat2.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import tempfile
 import unittest
 from q2_types.per_sample_sequences import ContigSequencesDirFmt, BAMDirFmt
-from q2_types.per_sample_sequences._format import MultiFASTADirectoryFormat
+from q2_types.per_sample_sequences import MultiFASTADirectoryFormat
 from unittest.mock import patch, ANY, call
 
 from qiime2.plugin.testing import TestPluginBase

--- a/q2_moshpit/partition/tests/test_mags.py
+++ b/q2_moshpit/partition/tests/test_mags.py
@@ -12,10 +12,10 @@ from q2_moshpit.partition.mags import (
     collate_feature_data_mags, collate_sample_data_mags
 )
 from qiime2.plugin.testing import TestPluginBase
-from q2_types.per_sample_sequences._format import (
+from q2_types.per_sample_sequences import (
     MultiMAGSequencesDirFmt,
 )
-from q2_types.feature_data_mag._format import (
+from q2_types.feature_data_mag import (
     MAGSequencesDirFmt
 )
 

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -41,8 +41,8 @@ from q2_types.kaiju import KaijuDB
 from q2_types.kraken2 import (
     Kraken2Reports, Kraken2Outputs, Kraken2DB, Kraken2DBReport
 )
-from q2_types.kraken2._type import BrackenDB
-from q2_types.per_sample_sequences._type import AlignmentMap
+from q2_types.kraken2 import BrackenDB
+from q2_types.per_sample_sequences import AlignmentMap
 from q2_types.reference_db import (
     ReferenceDB, Diamond, Eggnog, NCBITaxonomy, EggnogProteinSequences,
 )


### PR DESCRIPTION
Fixes some private imports.

Related to: https://github.com/qiime2/q2-types/pull/342