### PR TITLE
FIX: update how fetch-kaiju-db action discovers DB URLs

### DIFF
--- a/q2_moshpit/kaiju/tests/test_database.py
+++ b/q2_moshpit/kaiju/tests/test_database.py
@@ -10,12 +10,10 @@ import tempfile
 import unittest
 from unittest.mock import patch, Mock
 
-import pandas as pd
-from bs4 import BeautifulSoup
 from qiime2.plugin.testing import TestPluginBase
 
 from q2_moshpit.kaiju.database import (
-    _fetch_and_extract_db, _find_latest_db_url, _find_all_dbs,
+    _fetch_and_extract_db, _find_latest_db_url,
     fetch_kaiju_db, CHUNK_SIZE, ERR_MSG, KAIJU_SERVER_URL
 )
 from requests.exceptions import ConnectionError, RequestException
@@ -25,6 +23,50 @@ from q2_types.kaiju import KaijuDBDirectoryFormat
 
 class TestDatabaseFunctions(TestPluginBase):
     package = 'q2_moshpit.kaiju.tests'
+
+    def setUp(self):
+        super().setUp()
+        self.html_content = b''' # noqa: E501
+            <html><body>
+            <table>
+              <thead>
+                <tr>
+                  <th>Database</th>
+                  <th>Date</th>
+                  <th style="text-align: right">Archive size (GB)</th>
+                  <th style="text-align: right">RAM needed (GB)</th>
+                  <th>HTTPS URL</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td><strong>nr</strong></td><td colspan="4">Subset of NCBI BLAST <a href="https://ftp.ncbi.nlm.nih.gov/blast/db/v5/v5/FASTA/">nr</a> database containing Archaea, bacteria and viruses.</td></tr>
+                <tr>
+                  <td></td>
+                  <td>2023-05-10</td>
+                  <td style="text-align: right">67</td>
+                  <td style="text-align: right">177</td>
+                  <td><a href="https://kaiju-idx.s3.eu-central-1.amazonaws.com/2023/kaiju_db_nr_2023-05-10.tgz">.tgz</a></td>
+                </tr>
+                <tr><td><strong>nr_euk</strong></td><td colspan="4">Like nr, but additionally including fungi and microbial eukaryotes, see <a href="https://github.com/bioinformatics-centre/kaiju/blob/master/util/kaiju-taxonlistEuk.tsv">taxon list</a></td></tr>
+                <tr>
+                  <td></td>
+                  <td>2023-05-10</td>
+                  <td style="text-align: right">82</td>
+                  <td style="text-align: right">204</td>
+                  <td><a href="https://kaiju-idx.s3.eu-central-1.amazonaws.com/2023/kaiju_db_nr_euk_2023-05-10.tgz">.tgz</a></td>
+                </tr>
+                <tr><td><strong>refseq</strong></td><td colspan="4">Protein sequences from genome assemblies of Archaea and bacteria with assembly level "Complete Genome", as well as viral protein sequences from NCBI RefSeq.</td></tr>
+                <tr>
+                  <td></td>
+                  <td>2023-05-10</td>
+                  <td style="text-align: right">30</td>
+                  <td style="text-align: right">87</td>
+                  <td><a href="https://kaiju-idx.s3.eu-central-1.amazonaws.com/2023/kaiju_db_refseq_2023-05-23.tgz">.tgz</a></td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            '''
 
     @patch("requests.get")
     @patch("q2_moshpit.kaiju.database.tqdm")
@@ -72,68 +114,32 @@ class TestDatabaseFunctions(TestPluginBase):
                     "http://a/b/db.tar.gz", stream=True
                 )
 
-    def test_find_latest_db_url(self):
-        databases = [
-            ('nr_euk 2021-02-24 (61GB)',
-             'https://hello.com/nr_euk_2021-02-24.tar.gz'),
-            ('nr 2021-02-26 (52GB)',
-             'https://hello.com/nr_2021-02-26.tar.gz'),
-            ('nr_euk 2022-01-11 (60GB)',
-             'https://hello.com/nr_euk_2022-01-11.tar.gz')
-        ]
-        sidebox_element = BeautifulSoup(
-            '<html><body>{}</body></html>'.format(
-                ''.join('<a href={}>{}</a>'.format(d[1], d[0])
-                        for d in databases)
-            ), 'html.parser')
-        url = _find_latest_db_url(
-            database_type='nr_euk',
-            sidebox_element=sidebox_element,
-            url='https://test.com'
+    def test_find_latest_db_url_ok(self):
+        url = _find_latest_db_url(self.html_content, 'nr')
+        self.assertEqual(
+            url,
+            'https://kaiju-idx.s3.eu-central-1.amazonaws.com/2023/'
+            'kaiju_db_nr_2023-05-10.tgz'
         )
-        self.assertEqual(url, 'https://hello.com/nr_euk_2022-01-11.tar.gz')
 
-    def test_find_all_dbs(self):
-        databases = ['nr_euk 2021-02-24 (61GB)', 'nr 2021-02-26 (52GB)']
-        sidebox_element = BeautifulSoup(
-            '<html><body>{}</body></html>'.format(
-                ''.join('<a>{}</a>'.format(d) for d in databases)
-            ), 'html.parser')
-        df = _find_all_dbs(sidebox_element)
-        self.assertIsInstance(df, pd.DataFrame)
-        self.assertListEqual(
-            df.index.tolist(),
-            ['nr_euk 2021-02-24 (61GB)', 'nr 2021-02-26 (52GB)']
-        )
-        self.assertListEqual(
-            df['Date'].tolist(),
-            [pd.to_datetime('2021-02-24'), pd.to_datetime('2021-02-26')]
+    def test_find_latest_db_url_not_found(self):
+        with self.assertRaises(ValueError) as context:
+            _find_latest_db_url(self.html_content, 'non_existing_db')
+        self.assertIn(
+            "URL for database type 'non_existing_db' not found.",
+            str(context.exception)
         )
 
     @patch("requests.get")
     @patch("q2_moshpit.kaiju.database._fetch_and_extract_db")
     def test_fetch_kaiju_db(self, mock_fetch, mock_requests):
-        databases = [
-            ('nr_euk 2021-02-24 (61GB)',
-             'https://hello.com/nr_euk_2021-02-24.tar.gz'),
-            ('nr 2021-02-26 (52GB)',
-             'https://hello.com/nr_2021-02-26.tar.gz'),
-            ('nr_euk 2022-01-11 (60GB)',
-             'https://hello.com/nr_euk_2022-01-11.tar.gz')
-        ]
-        mock_requests.return_value = Mock(
-            content='<html><body><div id="sidebox_db">{}</div></body></html>'
-            .format(
-                ''.join('<a href={}>{}</a>'.format(d[1], d[0])
-                        for d in databases)
-            )
-        )
-
+        mock_requests.return_value = Mock(content=self.html_content)
         obs_db = fetch_kaiju_db('nr_euk')
         self.assertIsInstance(obs_db, KaijuDBDirectoryFormat)
         mock_requests.assert_called_with(KAIJU_SERVER_URL)
         mock_fetch.assert_called_with(
-            'https://hello.com/nr_euk_2022-01-11.tar.gz',
+            'https://kaiju-idx.s3.eu-central-1.amazonaws.com/2023/'
+            'kaiju_db_nr_euk_2023-05-10.tgz',
             str(obs_db.path)
         )
 

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -1345,6 +1345,8 @@ plugin.methods.register_function(
                 "nr",
                 "nr_euk",
                 "refseq",
+                "refseq_ref",
+                "refseq_nr",
                 "fungi",
                 "viruses",
                 "plasmids",

--- a/q2_moshpit/plugin_setup.py
+++ b/q2_moshpit/plugin_setup.py
@@ -1361,13 +1361,13 @@ plugin.methods.register_function(
     input_descriptions={},
     parameter_descriptions={
         "database_type": "Type of database to be downloaded. For more "
-        "information on available types please see the list on "
-        "Kaiju's web server: https://kaiju.binf.ku.dk/server",
+        "information on available types please see the list on Kaiju's web "
+        "server: https://bioinformatics-centre.github.io/kaiju/downloads.html",
     },
     output_descriptions={"database": "Kaiju database."},
     name="Fetch Kaiju database.",
     description="This method fetches the latest Kaiju database from "
-                "https://kaiju.binf.ku.dk/server.",
+                "Kaiju's web server.",
     citations=[citations["menzel2016"]],
 )
 


### PR DESCRIPTION
Closes #197.

To test, execute the action with a DB of choice (`viruses`, `plasmids` or `fungi` are some good, small DBs to try):
```
qiime moshpit fetch-kaiju-db \
  --p-database-type<db type> \
  --o-database db.qza \
  --verbose
``` 