### PR TITLE
LANG: relax busco pin for python 3.10 update

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - altair
     - beautifulsoup4
     - bracken
-    - busco ==5.5.0
+    - busco >=5.5.0
     - diamond
     - eggnog-mapper >=2.1.10
     - gfatools


### PR DESCRIPTION
Hey @misialq - I'm working on getting a solved metagenome environment for the python 3.10 update, and it looks like we'll have to bump the current version of `busco`. I did a bit of digging, and it looks like the reason for this pin came from the older `biopython` pin that was in assembly (that had to be removed for the python 3.9 update). I'm opening this paired PR so that I can test this change over in distributions, but this change won't need to go into effect until we get a solved metapackage with passing tests. So it can just be left as-is for now! I'll circle back with updates as I have them. 