### PR TITLE
CI: fix mamba version and some test file paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.9
-          mamba-version: "*"
+          mamba-version: 1.5.10
           channels: conda-forge,defaults
           channel-priority: true
           activate-environment: conda-env

--- a/q2_moshpit/kraken2/tests/test_bracken.py
+++ b/q2_moshpit/kraken2/tests/test_bracken.py
@@ -72,7 +72,7 @@ class TestBracken(TestPluginBase):
         )
 
         kraken2_report_fp = self.get_data_path(
-            'kraken2-reports-select/sample1/sample1.report.txt'
+            'kraken2-reports-select/samples/sample1.report.txt'
         )
         bracken_report_dir = self.get_data_path('bracken-report')
         obs_table = _run_bracken_one_sample(

--- a/q2_moshpit/kraken2/tests/test_bracken.py
+++ b/q2_moshpit/kraken2/tests/test_bracken.py
@@ -71,13 +71,11 @@ class TestBracken(TestPluginBase):
             os.path.join(self.temp_dir, 'sample1.bracken.output.txt')
         )
 
-        kraken2_report_fp = self.get_data_path(
-            'kraken2-report/sample1/sample1.report.txt'
-        )
+        kraken2_report_fp = tempfile.NamedTemporaryFile()
         bracken_report_dir = self.get_data_path('bracken-report')
         obs_table = _run_bracken_one_sample(
             bracken_db=self.bracken_db_dir,
-            kraken2_report_fp=kraken2_report_fp,
+            kraken2_report_fp=kraken2_report_fp.name,
             bracken_report_dir=bracken_report_dir,
             tmp_dir=self.temp_dir,
             threshold=self.kwargs['threshold'],
@@ -95,7 +93,7 @@ class TestBracken(TestPluginBase):
             cmd=[
                 "bracken", "-d", self.bracken_db_dir,
                 "-i",
-                kraken2_report_fp,
+                kraken2_report_fp.name,
                 "-o",
                 os.path.join(self.temp_dir, "sample1.bracken.output.txt"),
                 "-w",
@@ -113,15 +111,13 @@ class TestBracken(TestPluginBase):
         side_effect=CalledProcessError(returncode=123, cmd='bracken')
     )
     def test_run_bracken_one_sample_error(self, p1):
-        kraken2_report_fp = self.get_data_path(
-            'kraken2-report/sample1/sample1.report.txt'
-        )
+        kraken2_report_fp = tempfile.NamedTemporaryFile()
         bracken_report_dir = self.get_data_path('bracken-report')
 
         with self.assertRaisesRegex(Exception, 'return code 123'):
             _run_bracken_one_sample(
                 bracken_db=self.bracken_db_dir,
-                kraken2_report_fp=kraken2_report_fp,
+                kraken2_report_fp=kraken2_report_fp.name,
                 bracken_report_dir=bracken_report_dir,
                 tmp_dir=self.temp_dir,
                 threshold=self.kwargs['threshold'],

--- a/q2_moshpit/kraken2/tests/test_bracken.py
+++ b/q2_moshpit/kraken2/tests/test_bracken.py
@@ -71,11 +71,13 @@ class TestBracken(TestPluginBase):
             os.path.join(self.temp_dir, 'sample1.bracken.output.txt')
         )
 
-        kraken2_report_fp = tempfile.NamedTemporaryFile()
+        kraken2_report_fp = self.get_data_path(
+            'kraken2-reports-select/sample1/sample1.report.txt'
+        )
         bracken_report_dir = self.get_data_path('bracken-report')
         obs_table = _run_bracken_one_sample(
             bracken_db=self.bracken_db_dir,
-            kraken2_report_fp=kraken2_report_fp.name,
+            kraken2_report_fp=kraken2_report_fp,
             bracken_report_dir=bracken_report_dir,
             tmp_dir=self.temp_dir,
             threshold=self.kwargs['threshold'],
@@ -93,7 +95,7 @@ class TestBracken(TestPluginBase):
             cmd=[
                 "bracken", "-d", self.bracken_db_dir,
                 "-i",
-                kraken2_report_fp.name,
+                kraken2_report_fp,
                 "-o",
                 os.path.join(self.temp_dir, "sample1.bracken.output.txt"),
                 "-w",

--- a/q2_moshpit/kraken2/tests/test_database.py
+++ b/q2_moshpit/kraken2/tests/test_database.py
@@ -203,7 +203,9 @@ class TestKraken2Database(TestPluginBase):
 
     @patch('q2_moshpit.kraken2.database.run_command')
     def test_add_seqs_to_library(self, p1):
-        seqs = DNAFASTAFormat(self.get_data_path('mags/samp1/bin1.fa'), 'r')
+        seqs = DNAFASTAFormat(self.get_data_path(
+            'mags/sample1/3b72d1a7-ddb0-4dc7-ac36-080ceda04aaa.fasta'), 'r'
+        )
 
         _add_seqs_to_library(self.kraken2_db_dir, seqs=seqs, no_masking=True)
 
@@ -218,7 +220,9 @@ class TestKraken2Database(TestPluginBase):
         side_effect=CalledProcessError(123, 'cmd')
     )
     def test_add_seqs_to_library_exception(self, p1):
-        seqs = DNAFASTAFormat(self.get_data_path('mags/samp1/bin1.fa'), 'r')
+        seqs = DNAFASTAFormat(self.get_data_path(
+            'mags/sample1/3b72d1a7-ddb0-4dc7-ac36-080ceda04aaa.fasta'), 'r'
+        )
 
         with self.assertRaisesRegex(
                 Exception,


### PR DESCRIPTION
This PR:
- fixes mamba version used by the setup_miniconda to 1.5.10 to prevent CI failures cause by mamba 2.0.0
- updates paths to some test files 