### PR TITLE
CI: remove coverage testing from Q2 CI

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -10,24 +10,3 @@ jobs:
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
       distro: metagenome
-      additional-reports-path: ./coverage.xml
-      additional-reports-name: coverage
-
-  coverage:
-    needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        name: 'Fetch coverage from builds'
-        with:
-          name: ${{ needs.ci.outputs.additional-reports-name }}
-          path: ${{ needs.ci.outputs.additional-reports-path }}
-
-      - uses: codecov/codecov-action@v4
-        name: 'Upload coverage'
-        with:
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/q2-ci.yaml
+++ b/.github/workflows/q2-ci.yaml
@@ -18,25 +18,3 @@ jobs:
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
       distro: metagenome
-      additional-reports-path: ./coverage.xml
-      additional-reports-name: coverage
-
-  coverage:
-    needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        name: 'Fetch coverage from builds'
-        with:
-          name: ${{ needs.ci.outputs.additional-reports-name }}
-          path: ${{ needs.ci.outputs.additional-reports-path }}
-
-      - uses: codecov/codecov-action@v4
-        name: 'Upload coverage'
-        with:
-          fail_ci_if_error: true
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -42,13 +42,12 @@ requirements:
 
 test:
   requires:
-    - coverage
     - parameterized
   imports:
     - q2_moshpit
     - qiime2.plugins.moshpit
   commands:
-    - coverage run --rcfile ./repo/.coveragerc -m pytest && coverage xml -o coverage.xml
+    - pytest --pyargs q2_moshpit
 
 about:
   home: https://github.com/bokulich-lab/q2-moshpit


### PR DESCRIPTION
We will not test coverage when running QIIME 2 CI. This will only happen in one place, which is our other CI workflow (ci.yaml).