### PR TITLE
BUG: fix path in version file

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
-      distro: metagenome
+      distro: moshpit
       recipe-path: 'conda-recipe'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["main"]
 env:
-    DISTRO: metagenome
+    DISTRO: moshpit
 
 jobs:
   test:

--- a/.github/workflows/q2-ci.yaml
+++ b/.github/workflows/q2-ci.yaml
@@ -17,4 +17,4 @@ jobs:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/q2ci') }}
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
-      distro: metagenome
+      distro: moshpit

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 QIIME 2 plugin for functional annotation and taxonomic classification of shotgun metagenomes.
 
 ## Installation
-_q2-moshpit_ is available as part of the QIIME 2 metagenome distribution. For installation and usage instructions please consult the official [QIIME 2 documentation](https://docs.qiime2.org). 
+_q2-moshpit_ is available as part of the QIIME 2 moshpit distribution. For installation and usage instructions please consult the official [QIIME 2 documentation](https://docs.qiime2.org).
 
 ## Functionality
 This QIIME 2 plugin contains actions used to annotate and classify (meta)genomes:
@@ -25,7 +25,7 @@ This QIIME 2 plugin contains actions used to annotate and classify (meta)genomes
 | eggnog-diamond-search    | Run eggNOG search using diamond aligner. | [EggNOG mapper](https://github.com/eggnogdb/eggnog-mapper) |
 | eggnog-hmmer-search      | Run eggNOG search using HMMER aligner. | [EggNOG mapper](https://github.com/eggnogdb/eggnog-mapper) |
 | estimate-bracken         | Perform read abundance re-estimation using Bracken. | [Kraken 2](https://ccb.jhu.edu/software/bracken/) |
-| estimate-mag-abundance   | Estimate MAG abundance. | - | 
+| estimate-mag-abundance   | Estimate MAG abundance. | - |
 | evaluate-busco           | Evaluate quality of the generated MAGs using BUSCO. | [BUSCO](https://busco.ezlab.org) |
 | extract-annotations      | Extract annotation frequencies from all annotations. | - |
 | fetch-busco-db           | Download BUSCO database. | [BUSCO](https://busco.ezlab.org) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 
 [tool.versioningit.write]
-file = "q2-moshpit/_version.py"
+file = "q2_moshpit/_version.py"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
This PR fixes a typo in the path where the version file will be written to when the python package is built. This ensures that the correct version will be present when running 'qiime info' via the cli.
