### PR TITLE
MAINT: add env file for QIIME 2 2026.1

### DIFF
--- a/environment-files/q2-annotate-qiime2-moshpit-2026.1.yml
+++ b/environment-files/q2-annotate-qiime2-moshpit-2026.1.yml
@@ -1,0 +1,10 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/moshpit/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2-moshpit
+  - pip
+  - pip:
+    - q2-annotate@git+https://github.com/bokulich-lab/q2-annotate.git@2026.1.0
+    


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2026.1.

Generated from the latest env file in 'environment-files/' by updating the release token.