### PR TITLE
FIX: remove dependency on script when fetching the EggNOG database

### DIFF
--- a/q2_annotate/eggnog/dbs.py
+++ b/q2_annotate/eggnog/dbs.py
@@ -40,23 +40,67 @@ from q2_types.reference_db import (
 
 def fetch_eggnog_db() -> EggnogRefDirFmt:
     """
-    Downloads eggnog reference database using the
-    `download_eggnog_data.py` script from eggNOG. Here, this
-    script downloads 3 files amounting to 47Gb in total.
+    Downloads and prepares the eggNOG reference database (eggnog.db and taxa files)
+    directly from the EMBL server.
     """
-
-    # Initialize output objects
+    # Initialize output object
     eggnog_db = EggnogRefDirFmt()
+    data_dir = str(eggnog_db)
 
-    # Define command.
-    # Meaning of flags:
-    # y: Answer yes to all prompts thrown by download_eggnog_data.py
-    # D: Do not download the Diamond database
-    # data_dir: location where to save downloads
-    cmd = ["download_eggnog_data.py", "-y", "-D", "--data_dir", str(eggnog_db.path)]
-    run_command(cmd)
+    eggnog_db_gz = os.path.join(data_dir, "eggnog.db.gz")
+    taxa_tar_gz = os.path.join(data_dir, "eggnog.taxa.tar.gz")
 
-    # Return objects
+    base_url = "http://eggnog5.embl.de/download/emapperdb-5.0.2"
+
+    # Download eggnog.db.gz
+    print(colorify("Downloading eggnog.db.gz..."))
+    run_command(
+        cmd=[
+            "wget",
+            "-O",
+            eggnog_db_gz,
+            f"{base_url}/eggnog.db.gz",
+        ]
+    )
+
+    # Decompress eggnog.db.gz
+    print(colorify("Decompressing eggnog.db.gz..."))
+    run_command(cmd=["gunzip", eggnog_db_gz])
+
+    # Download eggnog.taxa.tar.gz
+    print(colorify("Downloading eggnog.taxa.tar.gz..."))
+    run_command(
+        cmd=[
+            "wget",
+            "-O",
+            taxa_tar_gz,
+            f"{base_url}/eggnog.taxa.tar.gz",
+        ]
+    )
+
+    # Extract taxa archive
+    print(colorify("Extracting eggnog.taxa.tar.gz..."))
+    run_command(
+        cmd=[
+            "tar",
+            "-zxf",
+            taxa_tar_gz,
+            "-C",
+            data_dir,
+        ]
+    )
+
+    # Remove archive after extraction
+    os.remove(taxa_tar_gz)
+
+    print(
+        colorify(
+            "Download and extraction completed.\n"
+            "Copying files from temporary directory to final location "
+            "(this may take a few minutes)..."
+        )
+    )
+
     return eggnog_db
 
 

--- a/q2_annotate/eggnog/tests/test_dbs.py
+++ b/q2_annotate/eggnog/tests/test_dbs.py
@@ -27,15 +27,57 @@ from q2_types.reference_db import NCBITaxonomyDirFmt, EggnogProteinSequencesDirF
 class TestFetchDB(TestPluginBase):
     package = "q2_annotate.eggnog.tests"
 
+    @patch("os.remove")
     @patch("subprocess.run")
-    def test_fetch_eggnog_db(self, subp_run):
-        # Call function. Patching will make sure nothing is
-        # actually ran
+    def test_fetch_eggnog_db(self, mock_run, mock_remove):
         eggnog_db = fetch_eggnog_db()
 
-        # Check that command was called in the expected way
-        cmd = ["download_eggnog_data.py", "-y", "-D", "--data_dir", str(eggnog_db)]
-        subp_run.assert_called_once_with(cmd, check=True)
+        data_dir = str(eggnog_db)
+        eggnog_db_gz = os.path.join(data_dir, "eggnog.db.gz")
+        taxa_tar_gz = os.path.join(data_dir, "eggnog.taxa.tar.gz")
+
+        base_url = "http://eggnog5.embl.de/download/emapperdb-5.0.2"
+
+        expected_calls = [
+            call(
+                [
+                    "wget",
+                    "-O",
+                    eggnog_db_gz,
+                    f"{base_url}/eggnog.db.gz",
+                ],
+                check=True,
+            ),
+            call(
+                [
+                    "gunzip",
+                    eggnog_db_gz,
+                ],
+                check=True,
+            ),
+            call(
+                [
+                    "wget",
+                    "-O",
+                    taxa_tar_gz,
+                    f"{base_url}/eggnog.taxa.tar.gz",
+                ],
+                check=True,
+            ),
+            call(
+                [
+                    "tar",
+                    "-zxf",
+                    taxa_tar_gz,
+                    "-C",
+                    data_dir,
+                ],
+                check=True,
+            ),
+        ]
+
+        mock_run.assert_has_calls(expected_calls, any_order=False)
+        mock_remove.assert_called_once_with(taxa_tar_gz)
 
     @patch("tempfile.TemporaryDirectory")
     @patch("q2_annotate.eggnog.dbs._download_and_build_hmm_db")


### PR DESCRIPTION
This PR addresses issue #315 by removing reliance on the broken Python script. Instead, the files `eggnog.db`, `eggnog.taxa.db`, and `eggnog.taxa.traverse.pkl` are being downloaded independently using Wget.